### PR TITLE
URL fragment issue

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -196,8 +196,10 @@
 
 
         var room = window.location.hash.slice(1);
-
-        rtc.connect("ws:" + window.location.href.substring(window.location.protocol.length), room);
+        var url = "ws:"+window.location.href.substring(window.location.protocol.length);
+        var hash = url.indexOf('#');
+        url = (hash !== -1) ? url.substring(0, hash) : url;
+        rtc.connect(url, room);
 
         rtc.on('add remote stream', function(stream, socketId) {
           console.log("ADDING REMOTE STREAM...");


### PR DESCRIPTION
There was an issue on page load when you have a room hash in the url.
You get a url fragment error and the socket connection does not succeed. This was making it impossible to join individual rooms
