### PR TITLE
Listing port defined in env variable

### DIFF
--- a/site/script.js
+++ b/site/script.js
@@ -155,7 +155,7 @@ function initChat() {
     }
   }, false);
   rtc.on(chat.event, function() {
-    data = chat.recv.apply(this, arguments);
+    var data = chat.recv.apply(this, arguments);
     console.log(data.color);
     addToChat(data.messages, data.color.toString(16));
   });

--- a/site/script.js
+++ b/site/script.js
@@ -1,5 +1,4 @@
 var videos = [];
-var rooms = [1, 2, 3, 4, 5];
 var PeerConnection = window.PeerConnection || window.webkitPeerConnection00 || window.webkitRTCPeerConnection;
 
 function getNumPerRow() {

--- a/site/server.js
+++ b/site/server.js
@@ -2,7 +2,8 @@ var app = require('express')();
 var server = require('http').createServer(app);
 var webRTC = require('webrtc.io').listen(server);
 
-server.listen(8000);
+var port = process.env.PORT || 8080;
+server.listen(port);
 
 
 


### PR DESCRIPTION
Server listen port can now be defined in environment variables (useful for Heroku, CloudBees, cloud9), fallback to 8080

Smaller code improvements
